### PR TITLE
Complaints response submit and visualization

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -18,9 +18,9 @@ require:
 Style/Documentation:
   Enabled: false
 
-Style/StringLiterals:
-  Enabled: true
-  EnforcedStyle: double_quotes
+# Style/StringLiterals:
+#   Enabled: true
+#   EnforcedStyle: double_quotes
 
 Style/StringLiteralsInInterpolation:
   Enabled: true
@@ -31,6 +31,7 @@ Style/ClassAndModuleChildren:
     - test/**/*.rb
 
 Metrics/BlockLength:
+  Max: 18
   Exclude:
     - config/environments/*.rb
     - config/routes.rb

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -18,9 +18,9 @@ require:
 Style/Documentation:
   Enabled: false
 
-# Style/StringLiterals:
-#   Enabled: true
-#   EnforcedStyle: double_quotes
+Style/StringLiterals:
+  Enabled: true
+  EnforcedStyle: double_quotes
 
 Style/StringLiteralsInInterpolation:
   Enabled: true

--- a/Gemfile
+++ b/Gemfile
@@ -1,46 +1,46 @@
 # frozen_string_literal: true
 
-source 'https://rubygems.org'
+source "https://rubygems.org"
 git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
-ruby '3.1.0'
-gem 'pg', '~> 1.3'
-gem 'puma', '~> 5.6'
-gem 'rails', '~> 7.0.1'
+ruby "3.1.0"
+gem "pg", "~> 1.3"
+gem "puma", "~> 5.6"
+gem "rails", "~> 7.0.1"
 
-gem 'aasm'
-gem 'bootsnap', require: false
-gem 'cloudinary'
-gem 'devise'
-gem 'image_processing', '~> 1.2'
-gem 'pundit'
-gem 'redis', '~> 4.6'
+gem "aasm"
+gem "bootsnap", require: false
+gem "cloudinary"
+gem "devise"
+gem "image_processing", "~> 1.2"
+gem "pundit"
+gem "redis", "~> 4.6"
 # gem "kredis"
 
-gem 'cssbundling-rails'
-gem 'jbuilder'
-gem 'jsbundling-rails'
-gem 'rails-i18n'
-gem 'sprockets-rails'
-gem 'stimulus-rails'
-gem 'turbo-rails'
+gem "cssbundling-rails"
+gem "jbuilder"
+gem "jsbundling-rails"
+gem "rails-i18n"
+gem "sprockets-rails"
+gem "stimulus-rails"
+gem "turbo-rails"
 
 group :development, :test do
-  gem 'debug', platforms: %i[mri mingw x64_mingw]
-  gem 'factory_bot_rails'
-  gem 'rubocop', require: false
-  gem 'rubocop-minitest', require: false
-  gem 'rubocop-performance', require: false
-  gem 'rubocop-rails', require: false
+  gem "debug", platforms: %i[mri mingw x64_mingw]
+  gem "factory_bot_rails"
+  gem "rubocop", require: false
+  gem "rubocop-minitest", require: false
+  gem "rubocop-performance", require: false
+  gem "rubocop-rails", require: false
 end
 
 group :development do
-  gem 'rack-mini-profiler'
-  gem 'web-console'
+  gem "rack-mini-profiler"
+  gem "web-console"
 end
 
 group :test do
-  gem 'capybara'
-  gem 'selenium-webdriver'
-  gem 'webdrivers'
+  gem "capybara"
+  gem "selenium-webdriver"
+  gem "webdrivers"
 end

--- a/Gemfile
+++ b/Gemfile
@@ -1,45 +1,46 @@
 # frozen_string_literal: true
 
-source "https://rubygems.org"
+source 'https://rubygems.org'
 git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
-ruby "3.1.0"
-gem "pg", "~> 1.3"
-gem "puma", "~> 5.6"
-gem "rails", "~> 7.0.1"
+ruby '3.1.0'
+gem 'pg', '~> 1.3'
+gem 'puma', '~> 5.6'
+gem 'rails', '~> 7.0.1'
 
-gem "bootsnap", require: false
-gem "cloudinary"
-gem "devise"
-gem "image_processing", "~> 1.2"
-gem "pundit"
-gem "redis", "~> 4.6"
+gem 'aasm'
+gem 'bootsnap', require: false
+gem 'cloudinary'
+gem 'devise'
+gem 'image_processing', '~> 1.2'
+gem 'pundit'
+gem 'redis', '~> 4.6'
 # gem "kredis"
 
-gem "cssbundling-rails"
-gem "jbuilder"
-gem "jsbundling-rails"
-gem "rails-i18n"
-gem "sprockets-rails"
-gem "stimulus-rails"
-gem "turbo-rails"
+gem 'cssbundling-rails'
+gem 'jbuilder'
+gem 'jsbundling-rails'
+gem 'rails-i18n'
+gem 'sprockets-rails'
+gem 'stimulus-rails'
+gem 'turbo-rails'
 
 group :development, :test do
-  gem "debug", platforms: %i[mri mingw x64_mingw]
-  gem "factory_bot_rails"
-  gem "rubocop", require: false
-  gem "rubocop-minitest", require: false
-  gem "rubocop-performance", require: false
-  gem "rubocop-rails", require: false
+  gem 'debug', platforms: %i[mri mingw x64_mingw]
+  gem 'factory_bot_rails'
+  gem 'rubocop', require: false
+  gem 'rubocop-minitest', require: false
+  gem 'rubocop-performance', require: false
+  gem 'rubocop-rails', require: false
 end
 
 group :development do
-  gem "rack-mini-profiler"
-  gem "web-console"
+  gem 'rack-mini-profiler'
+  gem 'web-console'
 end
 
 group :test do
-  gem "capybara"
-  gem "selenium-webdriver"
-  gem "webdrivers"
+  gem 'capybara'
+  gem 'selenium-webdriver'
+  gem 'webdrivers'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,8 @@
 GEM
   remote: https://rubygems.org/
   specs:
+    aasm (4.12.3)
+      concurrent-ruby (~> 1.0)
     actioncable (7.0.1)
       actionpack (= 7.0.1)
       activesupport (= 7.0.1)
@@ -298,6 +300,7 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
+  aasm
   bootsnap
   capybara
   cloudinary

--- a/app/controllers/complaints/status_controller.rb
+++ b/app/controllers/complaints/status_controller.rb
@@ -5,17 +5,19 @@ module Complaints
     before_action :set_complaint
 
     def update
-      if @complaint.send(params[:event]) && @complaint.update(complaint_params)
-        redirect_to complaint_path(@complaint), notice: 'Acción realizada satisfactoriamente'
+      evento = params[:evento].presence || params[:event]
+
+      if @complaint.send(evento) && @complaint.update(complaint_params)
+        redirect_to complaint_path(@complaint), notice: "Acción realizada satisfactoriamente"
       else
-        redirect_to complaint_path(@complaint), alert: 'No fue posible realizar la acción'
+        redirect_to complaint_path(@complaint), alert: "No fue posible realizar la acción"
       end
     end
 
     private
 
     def complaint_params
-      params.permit(:response, :evidences)
+      params.permit(:response, evidences: [])
     end
 
     def set_complaint

--- a/app/controllers/complaints/status_controller.rb
+++ b/app/controllers/complaints/status_controller.rb
@@ -5,7 +5,7 @@ module Complaints
     before_action :set_complaint
 
     def update
-      evento = params[:evento].presence || params[:event]
+      evento = params[:form_event].presence || params[:event]
 
       if @complaint.send(evento) && @complaint.update(complaint_params)
         redirect_to complaint_path(@complaint), notice: "Acción realizada satisfactoriamente"
@@ -21,7 +21,9 @@ module Complaints
     end
 
     def set_complaint
-      @complaint = complaint_scope.find_by(id: params[:complaint_id])
+      @complaint = complaint_scope.find(id: params[:complaint_id])
+
+      redirect_to dashboards_url, alert: "No fue posible localizar el reporte" unless @complaint
     end
 
     def complaint_scope

--- a/app/controllers/complaints/status_controller.rb
+++ b/app/controllers/complaints/status_controller.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+module Complaints
+  class StatusController < AuthorizationsController
+    before_action :set_complaint
+
+    def update
+      if @complaint.send(params[:event]) && @complaint.update(complaint_params)
+        redirect_to complaint_path(@complaint), notice: 'Acción realizada satisfactoriamente'
+      else
+        redirect_to complaint_path(@complaint), alert: 'No fue posible realizar la acción'
+      end
+    end
+
+    private
+
+    def complaint_params
+      params.permit(:response, :evidences)
+    end
+
+    def set_complaint
+      @complaint = complaint_scope.find_by(id: params[:complaint_id])
+    end
+
+    def complaint_scope
+      return current_user.complaints if current_user.citizen?
+
+      if current_user.director? || current_user.employee?
+        return Complaint.where(category_id: current_user.dependency.categories.pluck(:id))
+      end
+
+      Complaint
+    end
+  end
+end

--- a/app/controllers/complaints_controller.rb
+++ b/app/controllers/complaints_controller.rb
@@ -7,7 +7,7 @@ class ComplaintsController < AuthorizationsController
   def index; end
 
   def show
-    redirect_to dashboards_url, alert: "No se encontró el registro que buscas" unless @complaint
+    redirect_to dashboards_url, alert: 'No se encontró el registro que buscas' unless @complaint
   end
 
   def new
@@ -19,7 +19,7 @@ class ComplaintsController < AuthorizationsController
     @complaint.created!
 
     if @complaint.save
-      redirect_to complaint_url(@complaint), notice: "Ha sido generado y enviado exitosamente tu reporte."
+      redirect_to complaint_url(@complaint), notice: 'Ha sido generado y enviado exitosamente tu reporte.'
     else
       render :new, status: :unprocessable_entity
     end
@@ -27,7 +27,11 @@ class ComplaintsController < AuthorizationsController
 
   def edit; end
 
-  def update; end
+  def update
+    @complaint.update(complaint_params)
+
+    redirect_to complaint_url(@complaint), notice: 'Ha sido aplicada la transacción de forma exitosa'
+  end
 
   def destroy; end
 
@@ -53,6 +57,6 @@ class ComplaintsController < AuthorizationsController
 
   def complaint_params
     params.require(:complaint).permit(:user_id, :category_id, :subject, :description, :address, :neighbourhood, :town,
-                                      :latitude, :longitude, images: [])
+                                      :latitude, :longitude, :response, images: [], evidences: [])
   end
 end

--- a/app/controllers/complaints_controller.rb
+++ b/app/controllers/complaints_controller.rb
@@ -7,7 +7,7 @@ class ComplaintsController < AuthorizationsController
   def index; end
 
   def show
-    redirect_to dashboards_url, alert: "No se encontró el registro que buscas" unless @complaint
+    redirect_to dashboards_url, alert: "No se encontró el reporte que buscas" unless @complaint
   end
 
   def new

--- a/app/controllers/complaints_controller.rb
+++ b/app/controllers/complaints_controller.rb
@@ -7,7 +7,7 @@ class ComplaintsController < AuthorizationsController
   def index; end
 
   def show
-    redirect_to dashboards_url, alert: 'No se encontró el registro que buscas' unless @complaint
+    redirect_to dashboards_url, alert: "No se encontró el registro que buscas" unless @complaint
   end
 
   def new
@@ -19,7 +19,7 @@ class ComplaintsController < AuthorizationsController
     @complaint.created!
 
     if @complaint.save
-      redirect_to complaint_url(@complaint), notice: 'Ha sido generado y enviado exitosamente tu reporte.'
+      redirect_to complaint_url(@complaint), notice: "Ha sido generado y enviado exitosamente tu reporte."
     else
       render :new, status: :unprocessable_entity
     end
@@ -30,7 +30,7 @@ class ComplaintsController < AuthorizationsController
   def update
     @complaint.update(complaint_params)
 
-    redirect_to complaint_url(@complaint), notice: 'Ha sido aplicada la transacción de forma exitosa'
+    redirect_to complaint_url(@complaint), notice: "Ha sido aplicada la transacción de forma exitosa"
   end
 
   def destroy; end

--- a/app/helpers/complaints_helper.rb
+++ b/app/helpers/complaints_helper.rb
@@ -3,8 +3,8 @@
 module ComplaintsHelper
   STATUSES_CSS = { created: "is-dark",
                    in_process: "is-warning",
-                   attended: "is-info",
-                   attended_by_program: "is-info",
+                   attended: "is-success",
+                   attended_by_program: "is-success",
                    rejected: "is-danger" }.freeze
 
   def category_options_for(categories)

--- a/app/models/complaint.rb
+++ b/app/models/complaint.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class Complaint < ApplicationRecord
+  include AASM
+
   validates :subject, :address, :neighbourhood, :town, presence: true
   belongs_to :user
   belongs_to :category
@@ -9,9 +11,30 @@ class Complaint < ApplicationRecord
   delegate :dependency, to: :category
 
   enum :status,
-       { created: "created",
-         in_process: "in_process",
-         attended: "attended",
-         attended_by_program: "attended_by_program",
-         rejected: "rejected" }
+       { created: 'created',
+         in_process: 'in_process',
+         attended: 'attended',
+         attended_by_program: 'attended_by_program',
+         rejected: 'rejected' }
+
+  aasm column: :status, enum: true do
+    state :created, initial: true
+    state :in_process, :attended, :attended_by_program, :rejected
+
+    event :process do
+      transitions from: :created, to: :in_process
+    end
+
+    event :attend do
+      transitions from: :in_process, to: :attended
+    end
+
+    event :attend_program do
+      transitions from: :in_process, to: :attended_by_program
+    end
+
+    event :reject do
+      transitions from: :created, to: :rejected
+    end
+  end
 end

--- a/app/models/complaint.rb
+++ b/app/models/complaint.rb
@@ -11,11 +11,11 @@ class Complaint < ApplicationRecord
   delegate :dependency, to: :category
 
   enum :status,
-       { created: 'created',
-         in_process: 'in_process',
-         attended: 'attended',
-         attended_by_program: 'attended_by_program',
-         rejected: 'rejected' }
+       { created: "created",
+         in_process: "in_process",
+         attended: "attended",
+         attended_by_program: "attended_by_program",
+         rejected: "rejected" }
 
   aasm column: :status, enum: true do
     state :created, initial: true

--- a/app/views/complaints/_response_form.html.erb
+++ b/app/views/complaints/_response_form.html.erb
@@ -1,0 +1,46 @@
+<% if current_user.employee? %>
+  <% if @complaint.in_process? %>
+    <div class="columns">
+      <div class="column">
+        <%= form_with url: complaint_status_path(@complaint, 'attend'), method: :put, id: 'process_complaint', data: { turbo: false } do |f| %>
+          <div class="field is-horizontal">
+            <div class="field-label is-normal">
+              <label class="label">Respuesta</label>
+            </div>
+            <div class="field-body">
+              <div class="field">
+                <div class="control">
+                  <%= f.text_area :response, class: "textarea", placeholder: "Resúmen de las actividades realizadas" %>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div class="field is-horizontal">
+            <div class="field-label is-normal">
+              <label class="label">Evidencias</label>
+            </div>
+            <div class="field-body">
+              <div class="field">
+                <div class="file is-info has-name">
+                  <label class="file-label">
+                    <%= f.file_field :evidences, multiple: true, class: "file-input" %>
+                    <span class="file-cta">
+                      <span class="file-icon">
+                        <i class="fas fa-cloud-upload-alt" aria-hidden="true"></i>
+                      </span>
+                      <span class="file-label">
+                        Subir…
+                      </span>
+                    </span>
+                    <span class="file-name">
+                    </span>
+                  </label>
+                </div>
+              </div>
+            </div>
+          </div>
+        <% end %>
+      </div>
+    </div>
+  <% end %>
+<% end %>

--- a/app/views/complaints/_response_form.html.erb
+++ b/app/views/complaints/_response_form.html.erb
@@ -1,8 +1,22 @@
-<% if current_user.employee? %>
-  <% if @complaint.in_process? %>
-    <div class="columns">
-      <div class="column">
-        <%= form_with url: complaint_status_path(@complaint, 'attend'), method: :put, id: 'process_complaint', data: { turbo: false } do |f| %>
+<% if @complaint.created? || @complaint.in_process?%>
+  <div class="columns">
+    <div class="column">
+      <%= form_with url: complaint_status_path(@complaint, 'validate_complaint'), method: :put, id: 'process_complaint', multipart: true, data: { turbo: false } do |f| %>
+        <% if @complaint.created? %>
+          <div class="field is-horizontal">
+            <div class="field-label is-normal">
+              <label class="label">Jusitificación</label>
+            </div>
+            <div class="field-body">
+              <div class="field">
+                <div class="control">
+                  <%= f.text_area :response, class: "textarea", placeholder: "Cual es el motivo para no dar atención al reporte ciudadano" %>
+                </div>
+              </div>
+            </div>
+          </div>
+        <% end %>
+        <% if @complaint.in_process? %>
           <div class="field is-horizontal">
             <div class="field-label is-normal">
               <label class="label">Respuesta</label>
@@ -40,7 +54,7 @@
             </div>
           </div>
         <% end %>
-      </div>
+      <% end %>
     </div>
-  <% end %>
+  </div>
 <% end %>

--- a/app/views/complaints/_response_show.html.erb
+++ b/app/views/complaints/_response_show.html.erb
@@ -1,0 +1,33 @@
+<% if @complaint.rejected? || @complaint.attended? || @complaint.attended_by_program? %>
+  <% if @complaint.rejected? %>
+    <div class="column">
+      <article class="message is-danger">
+        <div class="message-header">
+          <p>Justificación</p>
+        </div>
+        <div class="message-body">
+          <%= @complaint.response %>
+        </div>
+      </article>
+    </div>
+  <% end %>
+  <% if  @complaint.attended? || @complaint.attended_by_program? %>
+    <div class="column">
+      <article class="message is-success">
+        <div class="message-header">
+          <p>Acciones realizadas</p>
+        </div>
+        <section class="message-body">
+          <%= @complaint.response %>
+        </section>
+      </article>
+    </div>
+    <%if @complaint.evidences%>
+      <div class="column">
+        <% @complaint.evidences.each do |image| %>
+          <%= display_image(image, type: :upload, width: 0.40, crop: "scale", quality: "auto", gravity: "auto", size: [150,150]) %>
+        <% end %>
+      </div>
+    <%end %>
+  <% end %>
+<% end %>

--- a/app/views/complaints/_users_actions.html.erb
+++ b/app/views/complaints/_users_actions.html.erb
@@ -10,19 +10,19 @@
         <% end %>
         <% if current_user.employee? %>
           <% if @complaint.created? %>
-            <%= link_to dashboards_url, class: "button is-info" do %>
+            <%= button_to complaint_status_path(@complaint, 'process'), method: :put, class: "button is-info" do %>
               <i class="fas fa-folder-open" aria-hidden="true"> </i>&nbsp;Recibir
             <% end %>
           <% end %>
-          <% if @complaint.created? %>
-            <%= link_to dashboards_url, class: "button is-success" do %>
+          <% if @complaint.in_process? %>
+            <%= button_tag type: 'submit', form:"process_complaint", class: "button is-success", disable_with: 'Procesando...' do %>
               <i class="fas fa-check-circle" aria-hidden="true"> </i>&nbsp;Atender
             <% end %>
-            <%= link_to dashboards_url, class: "button is-success" do %>
+            <%= button_tag type: 'submit', form:"process_complaint", class: "button is-success", disable_with: 'Procesando...' do %>
               <i class="fas fa-calendar-check" aria-hidden="true"> </i>&nbsp;Atender por programa
             <% end %>
           <% end %>
-          <% unless @complaint.attended? || @complaint.attended_by_program? %>
+          <% if @complaint.created? %>
             <%= link_to dashboards_url, class: "button is-danger" do %>
               <i class="fas fa-times-circle" aria-hidden="true"> </i>&nbsp;Rechazar
             <% end %>

--- a/app/views/complaints/_users_actions.html.erb
+++ b/app/views/complaints/_users_actions.html.erb
@@ -1,33 +1,35 @@
-<div class="field is-horizontal">
-  <div class="field-label">
-    <!-- Left empty for spacing -->
-  </div>
-  <div class="field-body">
-    <div class="field">
-      <div class="buttons">
-        <%= link_to dashboards_url, class: "button is-light" do %>
-          <i class="fas fa-chevron-circle-left" aria-hidden="true"> </i>&nbsp;Regresar
-        <% end %>
-        <% if current_user.employee? %>
-          <% if @complaint.created? %>
-            <%= button_to complaint_status_path(@complaint, 'process'), method: :put, class: "button is-info" do %>
-              <i class="fas fa-folder-open" aria-hidden="true"> </i>&nbsp;Recibir
+<div class="columns">
+  <div class="column">
+    <div class="field is-horizontal">
+      <div class="field-label">
+        <!-- Left empty for spacing -->
+      </div>
+      <div class="field-body">
+        <div class="field">
+          <div class="buttons">
+            <%= link_to dashboards_url, class: "button is-light" do %>
+              <i class="fas fa-chevron-circle-left" aria-hidden="true"> </i>&nbsp;Regresar
             <% end %>
-          <% end %>
-          <% if @complaint.in_process? %>
-            <%= button_tag type: 'submit', form:"process_complaint", class: "button is-success", disable_with: 'Procesando...' do %>
-              <i class="fas fa-check-circle" aria-hidden="true"> </i>&nbsp;Atender
+            <% if current_user.employee? %>
+              <% if @complaint.created? %>
+                <%= button_to complaint_status_path(@complaint, 'process'), method: :put, class: "button is-info" do %>
+                  <i class="fas fa-folder-open" aria-hidden="true"> </i>&nbsp;Recibir
+                <% end %>
+                <%= button_tag type: 'submit', form:"process_complaint", name: "evento", value: "reject", class: "button is-danger", disable_with: 'Procesando...' do %>
+                  <i class="fas fa-times-circle" aria-hidden="true"> </i>&nbsp;Rechazar
+                <% end %>
+              <% end %>
+              <% if @complaint.in_process? %>
+                <%= button_tag type: 'submit', form:"process_complaint", name: "evento", value: "attend", class: "button is-success", disable_with: 'Procesando...' do %>
+                  <i class="fas fa-check-circle" aria-hidden="true"> </i>&nbsp;Atender
+                <% end %>
+                <%= button_tag type: 'submit', form:"process_complaint", name: "evento", value: "attend_program", class: "button is-success", disable_with: 'Procesando...' do %>
+                  <i class="fas fa-calendar-check" aria-hidden="true"> </i>&nbsp;Atender por programa
+                <% end %>
+              <% end %>
             <% end %>
-            <%= button_tag type: 'submit', form:"process_complaint", class: "button is-success", disable_with: 'Procesando...' do %>
-              <i class="fas fa-calendar-check" aria-hidden="true"> </i>&nbsp;Atender por programa
-            <% end %>
-          <% end %>
-          <% if @complaint.created? %>
-            <%= link_to dashboards_url, class: "button is-danger" do %>
-              <i class="fas fa-times-circle" aria-hidden="true"> </i>&nbsp;Rechazar
-            <% end %>
-          <% end %>
-        <% end %>
+          </div>
+        </div>
       </div>
     </div>
   </div>

--- a/app/views/complaints/_users_actions.html.erb
+++ b/app/views/complaints/_users_actions.html.erb
@@ -15,15 +15,15 @@
                 <%= button_to complaint_status_path(@complaint, 'process'), method: :put, class: "button is-info" do %>
                   <i class="fas fa-folder-open" aria-hidden="true"> </i>&nbsp;Recibir
                 <% end %>
-                <%= button_tag type: 'submit', form:"process_complaint", name: "evento", value: "reject", class: "button is-danger", disable_with: 'Procesando...' do %>
+                <%= button_tag type: 'submit', form:"process_complaint", name: "form_event", value: "reject", class: "button is-danger", disable_with: 'Procesando...' do %>
                   <i class="fas fa-times-circle" aria-hidden="true"> </i>&nbsp;Rechazar
                 <% end %>
               <% end %>
               <% if @complaint.in_process? %>
-                <%= button_tag type: 'submit', form:"process_complaint", name: "evento", value: "attend", class: "button is-success", disable_with: 'Procesando...' do %>
+                <%= button_tag type: 'submit', form:"process_complaint", name: "form_event", value: "attend", class: "button is-success", disable_with: 'Procesando...' do %>
                   <i class="fas fa-check-circle" aria-hidden="true"> </i>&nbsp;Atender
                 <% end %>
-                <%= button_tag type: 'submit', form:"process_complaint", name: "evento", value: "attend_program", class: "button is-success", disable_with: 'Procesando...' do %>
+                <%= button_tag type: 'submit', form:"process_complaint", name: "form_event", value: "attend_program", class: "button is-success", disable_with: 'Procesando...' do %>
                   <i class="fas fa-calendar-check" aria-hidden="true"> </i>&nbsp;Atender por programa
                 <% end %>
               <% end %>

--- a/app/views/complaints/show.html.erb
+++ b/app/views/complaints/show.html.erb
@@ -25,8 +25,7 @@
             <p class="is-size-5"><strong>Domicilio:</strong> <%= "#{@complaint.address}, Col. #{@complaint.neighbourhood}" %></p>
           </div>
           <div class="column">
-            <p class="is-size-5">
-              <strong>Localidad:</strong> <%= "#{@complaint.town}"  %></span></p>
+            <p class="is-size-5"><strong>Localidad:</strong> <%= "#{@complaint.town}"  %></span></p>
         </div>
       </div>
       <div class="columns">
@@ -48,12 +47,17 @@
           </p>
         </div>
       </div>
-      <%= render "complaints/response_form"%>
+      <% if current_user.employee? %>
+        <%= render "complaints/response_form"%>
+      <% end %>
       <%= render "complaints/users_actions"%>
     </div>
     <div class="column is-8-mobile is-8-tablet is-3-desktop is-4-fullhd">
-      <%= image_tag 'complaint/complaint-detail.jpg', alt: "Detalle de reporte" %>
+      <% if @complaint.rejected? || @complaint.attended? || @complaint.attended_by_program? %>
+        <%= render "complaints/response_show"%>
+      <% else %>
+        <%= image_tag 'complaint/complaint-detail.jpg', alt: "Detalle de reporte" %>
+      <% end %>
     </div>
   </div>
-</div>
 </section>

--- a/app/views/complaints/show.html.erb
+++ b/app/views/complaints/show.html.erb
@@ -48,6 +48,7 @@
           </p>
         </div>
       </div>
+      <%= render "complaints/response_form"%>
       <%= render "complaints/users_actions"%>
     </div>
     <div class="column is-8-mobile is-8-tablet is-3-desktop is-4-fullhd">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,15 +2,20 @@
 
 Rails.application.routes.draw do
   devise_for :users, controllers: {
-    registrations: "users/registrations"
+    registrations: 'users/registrations'
   }
-  root "landing#index"
+  root 'landing#index'
 
   namespace :complaints do
-    get "/search", to: "search#index", as: "search"
+    get '/search', to: 'search#index', as: 'search'
   end
-  resources :dashboards, path: "ciudadano", only: [:index]
-  resources :complaints
+  resources :dashboards, path: 'ciudadano', only: [:index]
+
+  resources :complaints do
+    scope module: :complaints do
+      resources :status, param: :event, only: :update
+    end
+  end
 
   resources :categories
   resources :dependencies

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,14 +2,14 @@
 
 Rails.application.routes.draw do
   devise_for :users, controllers: {
-    registrations: 'users/registrations'
+    registrations: "users/registrations"
   }
-  root 'landing#index'
+  root "landing#index"
 
   namespace :complaints do
-    get '/search', to: 'search#index', as: 'search'
+    get "/search", to: "search#index", as: "search"
   end
-  resources :dashboards, path: 'ciudadano', only: [:index]
+  resources :dashboards, path: "ciudadano", only: [:index]
 
   resources :complaints do
     scope module: :complaints do

--- a/db/migrate/20220208233845_add_response_to_complaints.rb
+++ b/db/migrate/20220208233845_add_response_to_complaints.rb
@@ -1,0 +1,5 @@
+class AddResponseToComplaints < ActiveRecord::Migration[7.0]
+  def change
+    add_column :complaints, :response, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_02_05_205649) do
+ActiveRecord::Schema.define(version: 2022_02_08_233845) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -65,6 +65,7 @@ ActiveRecord::Schema.define(version: 2022_02_05_205649) do
     t.bigint "category_id", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.text "response"
     t.index ["category_id"], name: "index_complaints_on_category_id"
     t.index ["user_id"], name: "index_complaints_on_user_id"
   end


### PR DESCRIPTION
### Description
It's not possible to attend Complaints (chage status), and it's mandatory to have submit responses feature to citizen's complaints, this feature should be available only for _Employees_, besides, it's needed view the responses submitted.

### Solution
Implemented actions to process (attend) complaints; now is possible to _Receive, Attend, Attend by program or Reject_ every single complaint.

Added form for submitting responses from _complaints_ details view, it's possible to send a _response_ and/or _evidence_ (images); responses are presented in the same view.

### Screenshot

_Response form_:

The first avaliable _actions_ are _Receive or Reject_
![imagen](https://user-images.githubusercontent.com/1734773/153304088-014e57b7-c6f6-456b-a5bd-b52f32097cef.png)

Once is received a _complaint_, it's possible to _Attend or Attend by program_:
![imagen](https://user-images.githubusercontent.com/1734773/153304868-a485bb98-9e6d-4812-91c3-6853c139fd38.png)


_View response and/or evidences_:

<img width="1345" alt="imagen" src="https://user-images.githubusercontent.com/1734773/153304955-de9cff5c-d844-48fd-a5d7-83293e7b2394.png">

![imagen](https://user-images.githubusercontent.com/1734773/153305011-599e966c-b875-454b-a70c-deb6f522fb41.png)

